### PR TITLE
Fix possible fatal error

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -542,7 +542,11 @@ if ( ! class_exists( 'ezTOC' ) ) {
 				return $content;
 			}
 
-			$post = ezTOC_Post::get( get_the_ID() )->applyContentFilter()->process();
+			if ( ! $post = ezTOC_Post::get( get_the_ID() ) ) {
+				return $content;
+			}
+
+			$post->applyContentFilter()->process();
 
 			$find    = $post->getHeadings();
 			$replace = $post->getHeadingsWithAnchors();


### PR DESCRIPTION
Hey!

We were experiencing a fatal error:
`PHP Fatal error:  Uncaught Error: Call to a member function applyContentFilter() on null in plugins/Easy-Table-of-Contents/easy-table-of-contents.php:545` when doing a AJAX call. This check fixes it / prevents any other possible errors here when `ezTOC_Post` returns null.